### PR TITLE
Move mainClass back to root project level

### DIFF
--- a/system-summary-report-tool-install/build.gradle
+++ b/system-summary-report-tool-install/build.gradle
@@ -24,9 +24,7 @@ startScripts {
     }
 }
 
-tasks.named("run").configure {
-    mainClassName = 'gov.ca.dwr.callite.Main'
-}
+mainClassName = 'gov.ca.dwr.callite.Main'
 
 tasks.named('distTar').configure { enabled = false }
 distributions {
@@ -37,6 +35,10 @@ distributions {
             }
         }
     }
+}
+
+tasks.withType(Jar).configureEach {
+    enabled = false
 }
 
 distZip.dependsOn extractDll


### PR DESCRIPTION
This allows it to be inherited by both distribution and JavaExec tasks.

Additionally, disable jar task on install project, since it doesn't have any java code to publish and creates an unnecessary empty jar.